### PR TITLE
fix: use async response status for network request list and detail views

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -17,7 +17,9 @@ import {
   getFormattedResponseBody,
   getFormattedRequestBody,
   getShortDescriptionForRequest,
+  getShortDescriptionForRequestAsync,
   getStatusFromRequest,
+  getStatusFromRequestAsync,
 } from './formatters/networkFormatter.js';
 import {
   formatWebSocketConnectionShort,
@@ -344,7 +346,7 @@ export class McpResponse implements Response {
     });
   }
 
-  format(
+  async format(
     toolName: string,
     context: McpContext,
     data: {
@@ -355,7 +357,7 @@ export class McpResponse implements Response {
       consoleData: ConsoleMessageData | undefined;
       consoleListData: ConsoleMessageData[] | undefined;
     },
-  ): Array<TextContent | ImageContent> {
+  ): Promise<Array<TextContent | ImageContent>> {
     const response = [`# ${toolName} response`];
     for (const line of this.#textResponseLines) {
       response.push(line);
@@ -397,7 +399,7 @@ export class McpResponse implements Response {
       }
     }
 
-    response.push(...this.#formatNetworkRequestData(context, data.bodies));
+    response.push(...await this.#formatNetworkRequestData(context, data.bodies));
     response.push(...this.#formatConsoleData(data.consoleData));
 
     if (this.#networkRequestsOptions?.include) {
@@ -437,7 +439,7 @@ export class McpResponse implements Response {
         response.push(...data.info);
         for (const request of data.items) {
           response.push(
-            getShortDescriptionForRequest(
+            await getShortDescriptionForRequestAsync(
               request,
               context.getNetworkRequestStableId(request),
               context.getNetworkRequestStableId(request) ===
@@ -565,13 +567,13 @@ export class McpResponse implements Response {
     return response;
   }
 
-  #formatNetworkRequestData(
+  async #formatNetworkRequestData(
     context: McpContext,
     data: {
       requestBody?: string;
       responseBody?: string;
     },
-  ): string[] {
+  ): Promise<string[]> {
     const response: string[] = [];
     const id = this.#attachedNetworkRequestId;
     if (!id) {
@@ -580,7 +582,7 @@ export class McpResponse implements Response {
 
     const httpRequest = context.getNetworkRequestById(id);
     response.push(`## Request ${httpRequest.url()}`);
-    response.push(`Status:  ${getStatusFromRequest(httpRequest)}`);
+    response.push(`Status:  ${await getStatusFromRequestAsync(httpRequest)}`);
     response.push(`### Request Headers`);
     for (const line of getFormattedHeaderValue(httpRequest.headers())) {
       response.push(line);
@@ -617,7 +619,7 @@ export class McpResponse implements Response {
       let indent = 0;
       for (const request of redirectChain.reverse()) {
         response.push(
-          `${'  '.repeat(indent)}${getShortDescriptionForRequest(request, context.getNetworkRequestStableId(request))}`,
+          `${'  '.repeat(indent)}${await getShortDescriptionForRequestAsync(request, context.getNetworkRequestStableId(request))}`,
         );
         indent++;
       }

--- a/src/formatters/networkFormatter.ts
+++ b/src/formatters/networkFormatter.ts
@@ -28,6 +28,15 @@ export function getShortDescriptionForRequest(
   return `reqid=${id} [${request.resourceType()}] ${request.method()} ${request.url()} ${getStatusFromRequest(request)}${selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
 }
 
+export async function getShortDescriptionForRequestAsync(
+  request: HTTPRequest,
+  id: number,
+  selectedInDevToolsUI = false,
+): Promise<string> {
+  const status = await getStatusFromRequestAsync(request);
+  return `reqid=${id} [${request.resourceType()}] ${request.method()} ${request.url()} ${status}${selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
+}
+
 export function getStatusFromRequest(request: HTTPRequest): string {
   // In Playwright, request.response() is async, but we cache the failure info
   const failure = request.failure();


### PR DESCRIPTION
## Summary

- `list_network_requests` list and single-request detail views always showed `[pending]`, even after the page finished loading
- Some requests (beacon/analytics) were incorrectly reported as `[failed - net::ERR_ABORTED]` when they actually returned HTTP 200

## Root Cause

`getShortDescriptionForRequest` and `getStatusFromRequest` in `networkFormatter.ts` are synchronous, but Playwright's `request.response()` is async. The sync path can never obtain the real response status:

```ts
// Always returns [pending] — can't access response synchronously
export function getStatusFromRequest(request) {
    const failure = request.failure();
    if (failure) return `[failed - ${failure.errorText}]`;
    return '[pending]';
}
```

An async version `getStatusFromRequestAsync` already existed but was never called by the list or detail formatting code.

## Fix

1. **`src/formatters/networkFormatter.ts`** — Added `getShortDescriptionForRequestAsync`, which calls the existing `getStatusFromRequestAsync`
2. **`src/McpResponse.ts`** — Updated 3 call sites to use the async versions:
   - Request list loop (in `format()`)
   - Single-request detail status line (in `#formatNetworkRequestData()`)
   - Redirect chain status (in `#formatNetworkRequestData()`)
3. `format()` and `#formatNetworkRequestData()` method signatures changed to `async`

## Before / After

| Before | After |
|--------|-------|
| `GET .../api/feed/topstory/recommend ... [pending]` | `GET .../api/feed/topstory/recommend ... [success - 200]` |
| `POST .../za/logs/batch [failed - ERR_ABORTED]` | `POST .../za/logs/batch [success - 200]` |
| `Status: [pending]` | `Status: [success - 200]` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)