### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ claude mcp add js-reverse npx js-reverse-mcp
 codex mcp add js-reverse -- npx js-reverse-mcp
 ```
 
+### Autohand Code
+
+```bash
+autohand mcp add js-reverse npx js-reverse-mcp
+```
+
+添加 `--scope project`（放在 `js-reverse` 之前）可将服务器保存到当前项目的 `.autohand` 配置。安装详情请参阅 [Autohand Code CLI](https://github.com/autohandai/code-cli/)。
+
 ### Cursor
 
 进入 `Cursor Settings` -> `MCP` -> `New MCP Server`，使用上面的配置。

--- a/README_en.md
+++ b/README_en.md
@@ -65,6 +65,14 @@ claude mcp add js-reverse npx js-reverse-mcp
 codex mcp add js-reverse -- npx js-reverse-mcp
 ```
 
+### Autohand Code
+
+```bash
+autohand mcp add js-reverse npx js-reverse-mcp
+```
+
+Add `--scope project` before `js-reverse` to save the server in the current project's `.autohand` configuration. See the [Autohand Code CLI](https://github.com/autohandai/code-cli/) for installation details.
+
 ### Cursor
 
 Go to `Cursor Settings` -> `MCP` -> `New MCP Server`, and use the configuration above.


### PR DESCRIPTION
## What changed

Added Autohand Code setup commands to both the Chinese and English README client lists.

## Why

js-reverse-mcp already provides direct CLI setup for Claude Code and Codex plus guidance for Cursor and VS Code Copilot. Autohand Code can launch the same npm stdio server without any runtime changes.

## Validation

- Verified the command against the current Autohand Code MCP CLI implementation
- Kept the Chinese and English instructions aligned
- Ran `git diff --check`
